### PR TITLE
Give each Postgres test a schema of its own

### DIFF
--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -1,0 +1,133 @@
+// Package dbtest hands a test its own Postgres to work in.
+//
+// Two packages exercise the real schema — the migration test here and the
+// concurrent-bootstrap test in internal/server — and CI gives them one
+// database between them. `go test ./...` runs package binaries in parallel,
+// so both were dropping and recreating the same tables at the same time, and
+// each carried its own hand-written list of tables to drop first. That list
+// is the part that rots: it was written when there were fewer tables, so a
+// re-run met a `sessions` that the drop list had never heard of and the
+// migration failed on a relation that already existed.
+//
+// A schema of its own fixes both halves at once. Nothing is shared, so
+// nothing has to be dropped by name, and a table added to a migration cannot
+// leave a stale copy behind for the next run to trip over.
+package dbtest
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/OnyxAxisOwO/ObsidianArc/internal/config"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// DSNVariable is where a Postgres to test against is named. Without it every
+// caller skips, which is what keeps the suite runnable on a machine with no
+// database installed.
+const DSNVariable = "OBSIDIAN_TEST_POSTGRES_DSN"
+
+// Postgres returns a database configuration pointed at an empty schema of
+// this test's own, and drops the schema when the test ends.
+//
+// why is added to the skip message: a skipped Postgres test usually means the
+// thing it was covering went unchecked, and the caller knows what that is.
+func Postgres(t *testing.T, why string) config.Database {
+	t.Helper()
+
+	dsn := os.Getenv(DSNVariable)
+	if dsn == "" {
+		t.Skipf("set %s — %s", DSNVariable, why)
+	}
+
+	schema := schemaName(t)
+
+	admin := connect(t, dsn)
+	// Dropped first as well as last: a test killed part way through leaves
+	// its schema behind, and the next run with the same name should not
+	// inherit it.
+	exec(t, admin, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	exec(t, admin, `CREATE SCHEMA `+schema)
+	_ = admin.Close()
+
+	t.Cleanup(func() {
+		cleanup := connect(t, dsn)
+		defer cleanup.Close()
+		exec(t, cleanup, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	})
+
+	return config.Database{
+		Driver:       "postgres",
+		DSN:          withSearchPath(t, dsn, schema),
+		MaxOpenConns: 8,
+		MaxIdleConns: 4,
+	}
+}
+
+// schemaName is derived from the test's own name so a schema left behind by a
+// crash says which test left it.
+func schemaName(t *testing.T) string {
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		default:
+			return '_'
+		}
+	}, t.Name())
+
+	// Postgres truncates an identifier at 63 bytes, and a truncated one could
+	// collide with another test's; the tail is what differs between subtests,
+	// so it is the end that is kept.
+	const room = 56
+	if len(safe) > room {
+		safe = safe[len(safe)-room:]
+	}
+	return "oa_" + safe
+}
+
+// withSearchPath points a DSN at one schema, in whichever of the two shapes
+// libpq accepts it.
+func withSearchPath(t *testing.T, dsn, schema string) string {
+	t.Helper()
+
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		parsed, err := url.Parse(dsn)
+		if err != nil {
+			t.Fatalf("%s is not a usable URL: %v", DSNVariable, err)
+		}
+		query := parsed.Query()
+		query.Set("search_path", schema)
+		parsed.RawQuery = query.Encode()
+		return parsed.String()
+	}
+	// The keyword/value form, where parameters are separated by spaces.
+	return dsn + " search_path=" + schema
+}
+
+func connect(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	pool, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("connect to the test database: %v", err)
+	}
+	if err := pool.PingContext(context.Background()); err != nil {
+		pool.Close()
+		t.Fatalf("connect to the test database: %v", err)
+	}
+	return pool
+}
+
+func exec(t *testing.T, pool *sql.DB, statement string) {
+	t.Helper()
+	if _, err := pool.ExecContext(context.Background(), statement); err != nil {
+		t.Fatalf("%s: %v", statement, err)
+	}
+}

--- a/internal/database/dbtest/dbtest_test.go
+++ b/internal/database/dbtest/dbtest_test.go
@@ -1,0 +1,64 @@
+package dbtest
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// The two pure parts of this package, which are the parts that can be wrong
+// without a database to notice. Everything else here needs a real Postgres and
+// is therefore only ever exercised in CI; these two are not, so they are
+// checked where they can be.
+
+func TestSearchPathIsAddedWithoutLosingWhatIsAlreadyThere(t *testing.T) {
+	const dsn = "postgres://arc:arc@localhost:5432/arc_test?sslmode=disable"
+
+	parsed, err := url.Parse(withSearchPath(t, dsn, "oa_example"))
+	if err != nil {
+		t.Fatalf("the result is not a URL: %v", err)
+	}
+	query := parsed.Query()
+	if got := query.Get("search_path"); got != "oa_example" {
+		t.Errorf("search_path = %q, want oa_example", got)
+	}
+	// The parameter that was already on it decides whether the connection
+	// works at all, so losing it would be a confusing failure rather than an
+	// obvious one.
+	if got := query.Get("sslmode"); got != "disable" {
+		t.Errorf("sslmode = %q, want disable — the existing query was dropped", got)
+	}
+	if parsed.Host != "localhost:5432" || parsed.Path != "/arc_test" {
+		t.Errorf("host or database changed: %s", parsed)
+	}
+	if password, _ := parsed.User.Password(); password != "arc" {
+		t.Errorf("credentials changed: %s", parsed.User)
+	}
+}
+
+func TestSearchPathIsAddedToTheKeywordForm(t *testing.T) {
+	got := withSearchPath(t, "host=localhost user=arc dbname=arc_test", "oa_example")
+	const want = "host=localhost user=arc dbname=arc_test search_path=oa_example"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestASchemaNameIsUsableAsAnIdentifier(t *testing.T) {
+	name := schemaName(t)
+	if !strings.HasPrefix(name, "oa_") {
+		t.Errorf("name = %q, want the oa_ prefix that says who left it behind", name)
+	}
+	// Postgres truncates past 63 bytes, and a truncated name could collide
+	// with another test's — which would be a test dropping a schema it is not
+	// using.
+	if len(name) > 63 {
+		t.Errorf("name is %d bytes: %q", len(name), name)
+	}
+	for _, r := range name {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_' {
+			continue
+		}
+		t.Fatalf("name %q carries %q, which would need quoting", name, r)
+	}
+}

--- a/internal/database/portability_test.go
+++ b/internal/database/portability_test.go
@@ -3,12 +3,11 @@ package database
 import (
 	"context"
 	"io/fs"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/OnyxAxisOwO/ObsidianArc/internal/config"
+	"github.com/OnyxAxisOwO/ObsidianArc/internal/database/dbtest"
 )
 
 // The migrations run on two engines from one set of files. Nothing checks
@@ -107,29 +106,16 @@ func TestMigrationsApplyInOrder(t *testing.T) {
 //
 //	OBSIDIAN_TEST_POSTGRES_DSN=postgres://user:pass@localhost:5432/arc_test go test ./internal/database/
 func TestPostgresMigrations(t *testing.T) {
-	dsn := os.Getenv("OBSIDIAN_TEST_POSTGRES_DSN")
-	if dsn == "" {
-		t.Skip("set OBSIDIAN_TEST_POSTGRES_DSN to run the Postgres migration test")
-	}
-
+	// An empty schema of this test's own rather than the shared database with
+	// a list of tables dropped from it: the list only ever named the tables
+	// that existed when it was written, and one it had never heard of was
+	// enough to fail the migration that tried to create it again.
 	ctx := context.Background()
-	db, err := Open(ctx, config.Database{Driver: "postgres", DSN: dsn, MaxOpenConns: 4, MaxIdleConns: 2})
+	db, err := Open(ctx, dbtest.Postgres(t, "the dialect handling then goes unexercised"))
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
 	defer db.Close()
-
-	// A clean slate, so the test says something on a second run.
-	for _, table := range []string{
-		"schema_migrations", "usage_counters", "usage_records", "quota_policies",
-		"attachments", "messages", "conversations", "group_models", "models",
-		"api_key_models", "api_keys", "providers", "user_preferences", "settings",
-		"sessions", "users", "user_groups",
-	} {
-		if _, err := db.Exec(ctx, `DROP TABLE IF EXISTS `+table+` CASCADE`); err != nil {
-			t.Fatalf("drop %s: %v", table, err)
-		}
-	}
 
 	if _, err := db.Migrate(ctx); err != nil {
 		t.Fatalf("migrate: %v", err)

--- a/internal/server/bootstrap_test.go
+++ b/internal/server/bootstrap_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	"github.com/OnyxAxisOwO/ObsidianArc/internal/auth"
 	"github.com/OnyxAxisOwO/ObsidianArc/internal/config"
 	"github.com/OnyxAxisOwO/ObsidianArc/internal/database"
+	"github.com/OnyxAxisOwO/ObsidianArc/internal/database/dbtest"
 	"github.com/OnyxAxisOwO/ObsidianArc/internal/group"
 	"github.com/OnyxAxisOwO/ObsidianArc/internal/mail"
 	"github.com/OnyxAxisOwO/ObsidianArc/internal/settings"
@@ -45,13 +45,8 @@ func TestConcurrentBootstrapsCreateOneAdministrator(t *testing.T) {
 	})
 
 	t.Run("postgres is where the race is", func(t *testing.T) {
-		dsn := os.Getenv("OBSIDIAN_TEST_POSTGRES_DSN")
-		if dsn == "" {
-			t.Skip("set OBSIDIAN_TEST_POSTGRES_DSN — the SQLite run above cannot fail this")
-		}
-		raceBootstrap(t, t.TempDir(), config.Database{
-			Driver: "postgres", DSN: dsn, MaxOpenConns: 8, MaxIdleConns: 4,
-		})
+		raceBootstrap(t, t.TempDir(),
+			dbtest.Postgres(t, "the SQLite run above cannot fail this"))
 	})
 }
 
@@ -74,14 +69,10 @@ func raceBootstrap(t *testing.T, dir string, dbCfg config.Database) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	// A shared Postgres carries whatever the last run left behind, and this
-	// test is about an empty instance.
-	if dbCfg.Driver == "postgres" {
-		for _, table := range []string{"users", "user_groups", "settings"} {
-			_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS "+table+" CASCADE")
-		}
-		_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS schema_migrations CASCADE")
-	}
+	// Nothing is dropped first: on Postgres this runs in a schema of its own
+	// (see dbtest), and on SQLite in a file of its own. Emptiness comes from
+	// the database being new rather than from a list of tables to clear,
+	// which is the list that used to go stale as migrations added to it.
 	if _, err := db.Migrate(ctx); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}


### PR DESCRIPTION
CI has failed on every push since the tests that need a real Postgres were written — `34467518711`, `34369734219` and `34366209482` all die on the same line, in the same test, with the same error:

```
--- FAIL: TestConcurrentBootstrapsCreateOneAdministrator/postgres_is_where_the_race_is
    bootstrap_test.go:52: migrate: migration 0001_core statement 8:
        ERROR: relation "sessions" already exists (SQLSTATE 42P07)
```

Nothing else in the gate is red. This fixes that.

## Why it failed

Two packages exercise the real schema — the migration test in `internal/database` and the concurrent-bootstrap race in `internal/server` — and CI gives them one database between them. Each cleared it by dropping a hand-written list of tables and letting the migrations run again.

That list is the part that rots. `internal/server`'s named three tables plus `schema_migrations`, so dropping the ledger told the runner to apply everything from the beginning while thirteen tables it had never heard of were still standing. The first of those the migration reached was `sessions`.

There is a second half to it: `go test ./...` runs package binaries in parallel, so both tests were dropping and recreating tables in that one database at the same time — each able to pull the floor out from under the other.

## What changed

Both lists are gone. Each test now runs in a schema of its own, created and dropped around it, so emptiness comes from the database being new rather than from remembering what to delete — and a table added to a migration can no longer leave a stale copy behind for the next run. It also separates the two packages from each other.

The plumbing is a new test-only package, `internal/database/dbtest`. It reads the same `OBSIDIAN_TEST_POSTGRES_DSN`, skips the same way when there is none, and adds a `search_path` to it.

## For the reviewer

- **This cannot be verified on the machine it was written on.** There is no Docker and no Postgres there; both tests skip locally exactly as they did before, and the SQLite half of the bootstrap race still passes. CI is the only thing that can confirm the fix, which is what this PR is for.
- What *can* be checked without a database is checked: `dbtest`'s two pure parts — adding `search_path` to either DSN spelling without dropping the parameters already on it, and deriving an identifier Postgres will accept — carry tests, because they are the parts that can be wrong with nothing around to say so.
- A test-only package is a new file tree in a repository that keeps itself small. The alternative was the same helper copied into two packages, which is how the drop lists drifted apart in the first place.
- `internal/database/portability_test.go` is an in-package test, so the import direction matters: `dbtest` depends on `internal/config` and pgx, never on `internal/database`, or the test binary would not build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
